### PR TITLE
Remove DEFAULT_TIMEOUT from Redis config

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,6 +52,7 @@ netbox_config:
     - 127.0.0.1
   MEDIA_ROOT: "{{ netbox_install_directory }}/netbox/media"
   REPORTS_ROOT: "{{ netbox_install_directory }}/netbox/reports"
+  RQ_DEFAULT_TIMEOUT: 300
 
 # Housekeeping
 netbox_housekeeping: true

--- a/templates/configuration.py.j2
+++ b/templates/configuration.py.j2
@@ -15,7 +15,6 @@ REDIS = {
         'PORT': 6379,
         'PASSWORD': '',
         'DATABASE': 0,
-        'DEFAULT_TIMEOUT': 300,
         'SSL': False,
     },
     'caching': {
@@ -23,7 +22,6 @@ REDIS = {
         'PORT': 6379,
         'PASSWORD': '',
         'DATABASE': 1,
-        'DEFAULT_TIMEOUT': 300,
         'SSL': False,
     }
 }


### PR DESCRIPTION
Compensate by introducing the general config RQ_DEFAULT_TIMEOUT
parameter to defaults.

Related to https://github.com/netbox-community/netbox/issues/5171