### PR TITLE
Bypass secret key gen when defined

### DIFF
--- a/tasks/setup_netbox.yml
+++ b/tasks/setup_netbox.yml
@@ -93,6 +93,7 @@
   - name: set secret key in configuration
     set_fact:
       netbox_config: "{{ netbox_config | combine({'SECRET_KEY': __netbox_secret_key_file['content'] | b64decode}) }}"
+  when: netbox_config.SECRET_KEY is not defined
 
 - name: configure netbox
   template:


### PR DESCRIPTION
Hello,

Sometime we need to generate ourselves the secret key, especially when you have two netbox instance in HA.
Tell me if you need an issue linked to this PR or if the PR itself is enough.

Thanks.