### PR TITLE
netbox user: set shell to /bin/false

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,6 +24,7 @@
         name: "{{ netbox_user }}"
         group: "{{ netbox_group }}"
         home: "{{ netbox_user_home_directory }}"
+        shell: "/bin/false"
 
 - name: Setup database
   ansible.builtin.import_tasks: setup_database.yml


### PR DESCRIPTION
There is no need to have shell for netbox user, because of that we set the shell for netbox user to `/bin/false`.