### PR TITLE
Fix apt cache issue in certain cases

### DIFF
--- a/tasks/install_packages.yml
+++ b/tasks/install_packages.yml
@@ -2,9 +2,10 @@
 # Copyright (c) 2018-2020 Guillaume Mazoyer under the GPL License
 # Copyright (c) 2017-2018 Musee "lae" Ullah under the MIT License
 - name: Install required packages
-  ansible.builtin.package:
+  ansible.builtin.apt:
     name: "{{ __netbox_required_packages | flatten }}"
     state: present
+    update_cache: true
   vars:
     __netbox_required_packages:
       - "{{ netbox_python_packages }}"


### PR DESCRIPTION
As the role is meant for Debian/Ubuntu, it can leverage the use of `ansible.builtin.apt` (supports both distros) instead of `ansible.builtin.package`.
In some occasions the package installation fails because the package cache isn't updated:

```
ubuntu@netbox:~$ sudo apt install python3-venv
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Package python3-venv is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'python3-venv' has no installation candidate
```

Using `ansible.builtin.apt` permits having `update_cache: true`, that solves the issue.