### PR TITLE
Add some become's to enable usage of low privilged user account for setup

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,12 +2,14 @@
 - name: Reload systemd
   ansible.builtin.systemd:
     daemon_reload: true
+  become: true
 
 - name: Restart NetBox
   ansible.builtin.service:
     name: netbox
     state: restarted
     enabled: true
+  become: true
   when: netbox_setup_systemd | bool
 
 - name: Restart NetBox rqworker
@@ -15,6 +17,7 @@
     name: netbox-rqworker
     state: restarted
     enabled: true
+  become: true
   when: netbox_setup_systemd | bool
 
 - name: Restart Apache2
@@ -22,4 +25,5 @@
     name: "{{ netbox_apache2_service }}"
     state: restarted
     enabled: true
+  become: true
   when: netbox_setup_web_frontend | bool

--- a/tasks/install_packages.yml
+++ b/tasks/install_packages.yml
@@ -6,6 +6,7 @@
     name: "{{ __netbox_required_packages | flatten }}"
     state: present
     update_cache: true
+  become: true
   vars:
     __netbox_required_packages:
       - "{{ netbox_python_packages }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,6 +18,7 @@
     - name: Create NetBox group
       ansible.builtin.group:
         name: "{{ netbox_group }}"
+      become: true
 
     - name: Create NetBox user
       ansible.builtin.user:
@@ -25,6 +26,7 @@
         group: "{{ netbox_group }}"
         home: "{{ netbox_user_home_directory }}"
         shell: "/bin/false"
+      become: true
 
 - name: Setup database
   ansible.builtin.import_tasks: setup_database.yml

--- a/tasks/setup_netbox.yml
+++ b/tasks/setup_netbox.yml
@@ -13,6 +13,7 @@
     group: "{{ netbox_group }}"
     state: directory
     mode: "755"
+  become: true
   when: not netbox_installed.stat.exists
 
 - name: Download using git

--- a/tasks/setup_netbox.yml
+++ b/tasks/setup_netbox.yml
@@ -105,6 +105,8 @@
     owner: "{{ netbox_user }}"
     group: "{{ netbox_group }}"
     mode: "644"
+  become: true
+  become_user: "{{ netbox_user }}"
   notify:
     - Restart NetBox
     - Restart NetBox rqworker

--- a/tasks/setup_systemd.yml
+++ b/tasks/setup_systemd.yml
@@ -17,6 +17,8 @@
     owner: "{{ netbox_user }}"
     group: "{{ netbox_group }}"
     mode: "644"
+  become: true
+  become_user: "{{ netbox_user }}"
   notify:
     - Restart NetBox
 
@@ -27,6 +29,7 @@
     owner: root
     group: root
     mode: "644"
+  become: true
   notify:
     - Reload systemd
     - Restart NetBox
@@ -39,6 +42,7 @@
     owner: root
     group: root
     mode: "644"
+  become: true
   notify:
     - Reload systemd
     - Restart NetBox
@@ -60,6 +64,7 @@
         owner: "{{ netbox_user }}"
         group: "{{ netbox_group }}"
         mode: "644"
+      become: true
       with_dict: "{{ netbox_systemd_timers }}"
       notify:
         - Reload systemd
@@ -71,6 +76,7 @@
         owner: "{{ netbox_user }}"
         group: "{{ netbox_group }}"
         mode: "644"
+      become: true
       with_dict: "{{ netbox_systemd_timers }}"
       notify:
         - Reload systemd
@@ -82,6 +88,7 @@
         enabled: true
         masked: false
         scope: system
+      become: true
       when: item.value.enabled | bool
       with_dict: "{{ netbox_systemd_timers }}"
       notify:
@@ -94,6 +101,7 @@
         enabled: false
         masked: false
         scope: system
+      become: true
       when: not item.value.enabled | bool
       with_dict: "{{ netbox_systemd_timers }}"
       notify:


### PR DESCRIPTION
When running your role as low privileged user, `apply: become true` is required, like this:
```yaml
- ansible.builtin.include_role:
    name: "ansible-role-netbox"
    apply:
      become: true
```
to:
- install the required packages using apt
- create the netbox user
- create the netbox group and
- create the installation directory
- configure netbox
- systemd configuration
- handlers for service restarts

The following adjustments should fix this problem.