### PR TITLE
Replace | bool with "is truthy"

### DIFF
--- a/tasks/setup_netbox.yml
+++ b/tasks/setup_netbox.yml
@@ -61,7 +61,7 @@
     group: "{{ netbox_group }}"
     mode: "644"
   register: local_requirements_file
-  when: netbox_local_requirements | bool
+  when: netbox_local_requirements is truthy
 
 - name: Install local requirements
   ansible.builtin.pip:


### PR DESCRIPTION
Replace `| bool` with `is truthy`.  Fixes https://github.com/gmazoyer/ansible-role-netbox/issues/35

`| bool` does not do what one would [think](https://medium.com/opsops/wft-bool-filter-in-ansible-e7e2fd7a148f)